### PR TITLE
Extract authentication jwtSecret as a variable

### DIFF
--- a/charts/ks-devops-plugin/templates/config.yaml
+++ b/charts/ks-devops-plugin/templates/config.yaml
@@ -6,7 +6,7 @@ data:
       authenticateRateLimiterDuration: 10m0s
       loginHistoryRetentionPeriod: 168h
       maximumClockSkew: 10s
-      jwtSecret: "Z1TBo4jUSB5Rs6eyLqHSJ77GXtG8NhSP"
+      jwtSecret: {{ .Values.authentication.jwtSecret | quote }}
 kind: ConfigMap
 metadata:
   name: devops-plugin-config

--- a/charts/ks-devops-plugin/values.yaml
+++ b/charts/ks-devops-plugin/values.yaml
@@ -10,6 +10,10 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "master"
 
+authentication:
+  # If not set, jwt tools will generate and set it automatically
+  jwtSecret: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
### Why we need it

If we hard code authentication jwtSecret in helm charts, the jwt tools in init container of ks-devops-apiserver won't update jwt secret correctly, at least we should set the jwt secret with empty. If we integrate with KubeSphere, consistent secrets are required among ks-devops, ks-devops-plugin and KubeSphere, there is no way to set secret in ks-devops and ks-devops-plugin same as KubeSphere.

### What this PR does:

Extract authentication jwtSecret as a variable. Please refer to #70 for more information.

### Which issue(s) this PR fixes:

Fix https://github.com/kubesphere-sigs/ks-devops/issues/70

/kind bug