### PR TITLE
Add DevOps configuration into devops-plugin-config configmap

### DIFF
--- a/charts/ks-devops-plugin/templates/config.yaml
+++ b/charts/ks-devops-plugin/templates/config.yaml
@@ -7,6 +7,11 @@ data:
       loginHistoryRetentionPeriod: 168h
       maximumClockSkew: 10s
       jwtSecret: {{ .Values.authentication.jwtSecret | quote }}
+    devops:
+      host: http://ks-devops-jenkins.kubesphere-devops-system
+      username: admin
+      password: 117a817dcf053ff8e03be4e53b2b710f05
+      maxConnections: 100
 kind: ConfigMap
 metadata:
   name: devops-plugin-config


### PR DESCRIPTION
### Why we need it

When we integrate ks-devops-plugin into KubeSphere, we cannot list any devops project although we have created them.

### What this PR dose

After a period of investigation, we found a temporary solution to this problem which we add DevOps configuration into devops-plugin-config configmap. If we find a better solution in the future, this solution will be replaced.

### What kind of this PR

/kind bug